### PR TITLE
Fix security scan workflow failures

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -39,6 +39,7 @@ jobs:
         file: ./docker-app/Dockerfile
         push: false
         tags: face-detection-security-scan:latest
+        load: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
@@ -50,7 +51,7 @@ jobs:
         output: trivy-results.sarif
 
     - name: 📊 Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       if: always()
       with:
         sarif_file: trivy-results.sarif
@@ -63,9 +64,7 @@ jobs:
         docker run --rm -i hadolint/hadolint < docker-app/Dockerfile || true
         
         # Check for known vulnerabilities
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-          -v $PWD:/root/ \
-          -t aquasec/trivy:latest image \
+        docker run --rm aquasec/trivy:latest image \
           --severity HIGH,CRITICAL \
           face-detection-security-scan:latest
         


### PR DESCRIPTION
## Summary

This PR fixes the failing security scan workflow by addressing two issues:

1. **CodeQL Action Deprecation**: Updated from v2 to v3 as v2 is now deprecated
2. **Docker Image Loading**: Added `load: true` to ensure the built image is available locally for Trivy scanning

## Changes

- Updated CodeQL action from `github/codeql-action/upload-sarif@v2` to `@v3`
- Added `load: true` to the Docker build step to ensure the image is loaded into the local Docker daemon
- Simplified Trivy scan command by removing unnecessary volume mounts

## Testing

The workflow should now:
- ✅ Build the Docker image locally
- ✅ Run Trivy scan on the local image without authentication errors
- ✅ Upload results using the supported CodeQL action version

## Related Issues

Fixes the security scan failures seen in recent commits.