### PR TITLE
Fix Trivy Docker access issue in security scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -63,10 +63,16 @@ jobs:
         # Check for security best practices
         docker run --rm -i hadolint/hadolint < docker-app/Dockerfile || true
         
-        # Check for known vulnerabilities
-        docker run --rm aquasec/trivy:latest image \
+        # Export the image to a tar file for Trivy to scan
+        docker save face-detection-security-scan:latest -o image.tar
+        
+        # Check for known vulnerabilities using the tar file
+        docker run --rm -v $PWD:/workspace aquasec/trivy:latest image \
           --severity HIGH,CRITICAL \
-          face-detection-security-scan:latest
+          --input /workspace/image.tar
+        
+        # Clean up
+        rm -f image.tar
         
         echo "✅ Security scan completed!"
 


### PR DESCRIPTION
## Summary

This PR fixes the remaining issue with the security scan workflow where Trivy couldn't access the locally built Docker image.

## Problem

After the previous fix, Trivy was failing with:
- "Cannot connect to the Docker daemon at unix:///var/run/docker.sock"
- This happened because Trivy runs in its own container and can't access the host's Docker daemon

## Solution

- Export the built image to a tar file using `docker save`
- Mount the tar file into the Trivy container
- Use Trivy's `--input` flag to scan the tar file
- Clean up the temporary tar file after scanning

## Testing

The workflow should now:
- ✅ Build the Docker image locally
- ✅ Export it to a tar file
- ✅ Run Trivy scan on the tar file without Docker daemon access issues
- ✅ Complete the security scan successfully

## Related Issues

Fixes the remaining security scan failures after PR #1.